### PR TITLE
Add sla

### DIFF
--- a/BioCro/DARPA/upload_params.Rmd
+++ b/BioCro/DARPA/upload_params.Rmd
@@ -322,7 +322,7 @@ if(!dir.exists(paste0("upload_params_data/SLA/"))){
 write.csv(sla, file = "upload_params_data/SLA/sla.csv", row.names = FALSE)
 ```
 
-Split dataframe by new data since last  upload. 
+Split dataframe by new data since last upload. 
 ```{r}
 psla <- read.csv("upload_params_data/SLA/sla.csv")
 psla$local_datetime <- as.POSIXct(psla$local_datetime)

--- a/BioCro/DARPA/upload_params.Rmd
+++ b/BioCro/DARPA/upload_params.Rmd
@@ -19,7 +19,7 @@ library(udunits2)
 
 Read in parameters data from [sentinel-detection repository](https://github.com/danforthcenter/sentinel-detection), which should be cloned into the same folder as model-vignettes repo. 
 ```{r}
-all_parameters <- read.csv("../../../sentinel-detection/parameters_pipeline/outputs/parameters_data.csv")
+all_parameters <- read.csv("../../../sentinel-detection/data/derived_data/parameters_data.csv")
 ```
 
 Clean up data to have the final columns: 
@@ -90,8 +90,11 @@ upload_parameters$entity <- paste0(upload_parameters$Date, "_", upload_parameter
                                    upload_parameters$rep)
 ```
 
-Save cleaned parameter as a .csv file in `upload_params_data` folder in `model-vignettes/BioCro/DARPA`. 
+Save cleaned physiological parameters as a .csv file in the `phys_params` subfolder of `upload_params_data`. 
 ```{r}
+if(!dir.exists(paste0("upload_params_data/phys_params/"))){
+  dir.create(paste0("upload_params_data/phys_params/"), recursive = T)
+}
 write.csv(upload_parameters, "upload_params_data/phys_params/phys_parameters.csv", row.names = FALSE)
 ```
 
@@ -289,7 +292,7 @@ sla_JollyG <- left_join(leaf_area_JollyG, leaf_biomass_JollyG, by = "plant_id") 
   mutate(statname = '')
 ```
 
-Combine, format, and save SLA data as a .csv. 
+Combineand format all SLA values for upload. 
 ```{r}
 sla <- bind_rows(sla_hightemp, sla_control, sla_gh, sla_5cm, sla_JollyG) %>%
   mutate(site = case_when(treatment == "high light" ~ "Donald Danforth Plant Science Center Growth Chamber", 
@@ -308,10 +311,18 @@ sla <- bind_rows(sla_hightemp, sla_control, sla_gh, sla_5cm, sla_JollyG) %>%
          species, cultivar, site, treatment, local_datetime, 
          SLA, access_level)
 
+```
+
+Save cleaned SLA as a .csv file in the `SLA` subfolder of `upload_params_data`. 
+```{r}
+if(!dir.exists(paste0("upload_params_data/SLA/"))){
+  dir.create(paste0("upload_params_data/SLA/"), recursive = T)
+}
+
 write.csv(sla, file = "upload_params_data/SLA/sla.csv", row.names = FALSE)
 ```
 
-Split dataframe by new data since last  upload. Uploading to BETYdb using the API requires one file per parameter. 
+Split dataframe by new data since last  upload. 
 ```{r}
 psla <- read.csv("upload_params_data/SLA/sla.csv")
 psla$local_datetime <- as.POSIXct(psla$local_datetime)

--- a/BioCro/DARPA/upload_params.Rmd
+++ b/BioCro/DARPA/upload_params.Rmd
@@ -15,17 +15,11 @@ library(readxl)
 library(udunits2)
 ```
 
-## Physiological parameters Vmax, Rd, AQY, stomatal slope, and cuticular conductance f
+## Physiological parameters Vmax, Rd, AQY, stomatal slope, and cuticular conductance
 
 Read in parameters data from [sentinel-detection repository](https://github.com/danforthcenter/sentinel-detection), which should be cloned into the same folder as model-vignettes repo. 
 ```{r}
 all_parameters <- read.csv("../../../sentinel-detection/parameters_pipeline/outputs/parameters_data.csv")
-```
-
-Read in previous phys_parameters.csv; will need to constrain to latest data. 
-```{r}
-phys <- read.csv("upload_params_data/phys_parameters.csv")
-phys$local_datetime <- as.POSIXct(phys$local_datetime)
 ```
 
 Clean up data to have the final columns: 
@@ -98,22 +92,25 @@ upload_parameters$entity <- paste0(upload_parameters$Date, "_", upload_parameter
 
 Save cleaned parameter as a .csv file in `upload_params_data` folder in `model-vignettes/BioCro/DARPA`. 
 ```{r}
-write.csv(upload_parameters, "upload_params_data/phys_parameters.csv", row.names = FALSE)
+write.csv(upload_parameters, "upload_params_data/phys_params/phys_parameters.csv", row.names = FALSE)
 ```
 
 
 Split dataframe, first by new data since last  upload, then by parameter. Uploading to BETYdb using the API requires one file per parameter. 
 ```{r}
+#read in previous data
+pparams <- read.csv("upload_params_data/phys_params/phys_parameters.csv")
+pparams$local_datetime <- as.POSIXct(pparams$local_datetime)
 #create new folder with date
 dname <- gsub('-', '', grep(max(upload_parameters$local_datetime), pattern = "(\\D+)", value = T))
 
-if(!dir.exists(paste0("upload_params_data/", dname))){
-  dir.create(paste0("upload_params_data/", dname))
+if(!dir.exists(paste0("upload_params_data/phys_params/", dname))){
+  dir.create(paste0("upload_params_data/phys_params/", dname))
 }
-newdir <- paste0("upload_params_data/", dname)
+newdir <- paste0("upload_params_data/phys_params/", dname)
 
 #previous maximum date
-prevDate <- max(phys$local_datetime)
+prevDate <- max(pparams$local_datetime)
 
 #split dataframe for each parameter type and save each dataframe as a csv 
 params <- c("Vcmax", "leaf_respiration_rate_m2", "quantum_efficiency", "theta", "stomatal_slope.BB", "cuticular_cond")
@@ -134,10 +131,10 @@ for(p in params){
 }
 ```
 
-Upload that new parameter data file using the API. NOTE: Must update to latest folder (date), which on the R side is the variable 'dname'. 
+Upload that new parameter data file using the API.
 ```{bash}
 #change to directory of latest date
-x=$(ls -d ~/model-vignettes/BioCro/DARPA/upload_params_data/*/ | sort -r | head -n 1)
+x=$(ls -d ~/model-vignettes/BioCro/DARPA/upload_params_data/phys_params/*/ | sort -r | head -n 1)
 cd $x
 
 #add all .csv files from this diretory
@@ -147,15 +144,22 @@ done
 ```
 
 
-## Specific leaf area
+## Specific Leaf Area
 
 These SLA values are calculated from leaf area and leaf dry biomass. Below, the data are read in, filtered, and combined to produce specific leaf area in units of m2/kg. 
 
 These are the final columns:
 
-1. `local_datetime`: convert date into machine readable format
-2. `treatment`: specifies record's treatment using BETYdb treatment names
-3. `SLA`: values of specific leaf area in m2/kg
+
+1. `citation_author`, `citation_year`, and `citation_title`: indicate the source of the data using author, year, and title from BETYdb
+2. `species`: Setaria viridis, `cultivar`: ME-034
+3. `site`: one of three sites at Donald Danforth Plant Science Center, either Growth Chamber, Greenhouse, or Outdoor, using BETYdb site names
+4. `treatment`: specifies record's treatment using BETYdb treatment names
+5. `local_datetime`: convert date into machine readable format
+6.  `SLA`: Specific Leaf Area calculated from single-sided fresh leaf area divided by leaf dry mass, m2/kg
+8. `n`: sample size, always set to 1
+9. `access_level`: 2, equivalent to Internal & Collaborators
+
 
 First, load in data from the chamber experiments, an Excel sheet entitled "manual-measurements-Darpa_setaria_chambers_experiments.xlsx", which consists of multiple tabs. All leaf areas are avaiable in tab 'total_leaf_area'; biomass for the high night temperature experiment are found in '3rd_Biomass_ME034_GA_Exp' and the biomass for the high light experiment are found in '5th_Biomass_A10&ME034_cycling_t'. Note that because physiological and biomass data were taken on different individual plants, unique filters are applied to each biomass data to obtain the same set of experimental conditions as the physiological data. 
 ```{r}
@@ -212,13 +216,132 @@ sla_control <- left_join(leaf_biomass_control, leaf_area_control, by = "plantID"
          treatment = "high light") %>% 
   select(local_datetime, treatment, SLA) %>% 
   mutate(statname = '')
-
-sla <- bind_rows(sla_hightemp, sla_control)
 ```
 
-Save SLA data as a .csv. 
+Next, load in data from the outdoor and greenhouse experiments, an Excel sheet entitled "field_and_greenhouse_experiments.xlsx", which consists of multiple tabs. All leaf areas are avaiable in tab 'total_leaf_area'; biomass for the greenhouse experiment and 1st/2nd field experiments are found in '1st_gh_biomass', '1st_field_biomass', and '2nd_field_biomass', respectively. Again, physiological and biomass data were taken on different individual plants. In this case, the greenhouse physiological data came from pots and teh outdoor physiological data came from 5 cm and JollyG pots. Unique filters are applied to each biomass data to obtain the same set of experimental conditions as the physiological data. 
+
 ```{r}
-write.csv(sla, file = "upload_params_data/sla.csv", row.names = FALSE)
+# Data from chamber experiments
+data_path2 <- "../../../sentinel-detection/data/raw_data/biomass/field_and_greenhouse_experiments.xlsx"
+sheets_names2 <- excel_sheets(data_path2)
+
+# Biomass and leaf area for greenhouse pots
+leaf_biomass_gh <- read_excel(data_path2, sheets_names2[14]) %>% 
+  dplyr::rename(leaf_dry_biomass_g = 16) %>% # leaf DW was entered as g instead of mg
+  filter(treatment == "pot") %>% 
+  mutate(leaf_dry_biomass_g == as.numeric(leaf_dry_biomass_g))
+
+leaf_area_gh <- read_excel(data_path2, sheets_names2[1]) %>% 
+  dplyr::rename(leaf_area_cm2 = 9) %>% 
+  filter(experiment == "1st_gh_biomass", 
+         treatment == "pot")
+
+sla_gh <- left_join(leaf_area_gh, leaf_biomass_gh, by = "plant_id") %>% 
+  mutate(sla_initial_units = leaf_area_cm2 / leaf_dry_biomass_g, 
+         dry_biomass_kg = ud.convert(leaf_dry_biomass_g, "g", "kg"), 
+         area_m2 = ud.convert(leaf_area_cm2, "cm2", "m2"), 
+         SLA = area_m2 / dry_biomass_kg) %>% 
+  mutate(local_datetime = as.Date(`harvested`), 
+         treatment = "greenhouse") %>% 
+  select(local_datetime, treatment, SLA) %>% 
+  mutate(statname = '')
+
+# Biomass and leaf area for 2nd field experiment, 5 cm
+leaf_biomass_5cm <- read_excel(data_path2, sheets_names2[6]) %>% 
+  dplyr::rename(leaf_dry_biomass_g = 16) %>% # leaf DW was entered as g instead of mg
+  filter(treatment == "5cm") %>% 
+  mutate(leaf_dry_biomass_g == as.numeric(leaf_dry_biomass_g))
+
+leaf_area_5cm <- read_excel(data_path2, sheets_names2[1]) %>% 
+  dplyr::rename(leaf_area_cm2 = 9) %>% 
+  filter(experiment == "2nd_field_biomass", 
+         treatment == "5cm")
+
+sla_5cm <- left_join(leaf_area_5cm, leaf_biomass_5cm, by = "plant_id") %>% 
+  mutate(sla_initial_units = leaf_area_cm2 / leaf_dry_biomass_g, 
+         dry_biomass_kg = ud.convert(leaf_dry_biomass_g, "g", "kg"), 
+         area_m2 = ud.convert(leaf_area_cm2, "cm2", "m2"), 
+         SLA = area_m2 / dry_biomass_kg) %>% 
+  mutate(local_datetime = as.Date(`harvested`), 
+         treatment = "outdoor 5 cm density") %>% 
+  select(local_datetime, treatment, SLA) %>% 
+  mutate(statname = '')
+
+# Biomass and leaf area for 2nd field experiment, JollyG
+leaf_biomass_JollyG <- read_excel(data_path2, sheets_names2[6]) %>% 
+  dplyr::rename(leaf_dry_biomass_g = 16) %>% # leaf DW was entered as g instead of mg
+  filter(treatment == "jolly_pot") %>% 
+  mutate(leaf_dry_biomass_g == as.numeric(leaf_dry_biomass_g))
+
+leaf_area_JollyG <- read_excel(data_path2, sheets_names2[1]) %>% 
+  dplyr::rename(leaf_area_cm2 = 9) %>% 
+  filter(experiment == "2nd_field_biomass", 
+         treatment == "jolly_p")
+
+sla_JollyG <- left_join(leaf_area_JollyG, leaf_biomass_JollyG, by = "plant_id") %>% 
+  mutate(sla_initial_units = leaf_area_cm2 / leaf_dry_biomass_g, 
+         dry_biomass_kg = ud.convert(leaf_dry_biomass_g, "g", "kg"), 
+         area_m2 = ud.convert(leaf_area_cm2, "cm2", "m2"), 
+         SLA = area_m2 / dry_biomass_kg) %>% 
+  mutate(local_datetime = as.Date(`harvested`), 
+         treatment = "outdoor JollyG soil") %>% 
+  select(local_datetime, treatment, SLA) %>% 
+  mutate(statname = '')
 ```
 
-Upload values to Welsch BETYdb using the same method as for physiological parameters. 
+Combine, format, and save SLA data as a .csv. 
+```{r}
+sla <- bind_rows(sla_hightemp, sla_control, sla_gh, sla_5cm, sla_JollyG) %>%
+  mutate(site = case_when(treatment == "high light" ~ "Donald Danforth Plant Science Center Growth Chamber", 
+                               treatment == "high night temperature" ~ "Donald Danforth Plant Science Center Growth Chamber",
+                               treatment == "greenhouse" ~ "Donald Danforth Plant Science Center Greenhouse",
+                               treatment == "outdoor 5 cm density" ~ "Donald Danforth Plant Science Center Outdoor",
+                               treatment == "outdoor JollyG soil" ~ "Donald Danforth Plant Science Center Outdoor"),
+         species = "Setaria viridis",
+         cultivar = "ME-034",
+         citation_author = "Zhang, Gehan, LeBauer, Riemer, Tarin, Vargas",
+         citation_year = "2018", 
+         citation_title = "Unpublished DARPA experimental data",
+         n = 1, 
+         access_level = "2",
+         SLA = round(SLA, 2)) %>%
+  select(citation_author, citation_year, citation_title, 
+         species, cultivar, site, treatment, local_datetime, 
+         SLA, n, access_level)
+
+write.csv(sla, file = "upload_params_data/SLA/sla.csv", row.names = FALSE)
+```
+
+Split dataframe by new data since last  upload. Uploading to BETYdb using the API requires one file per parameter. 
+```{r}
+psla <- read.csv("upload_params_data/SLA/sla.csv")
+psla$local_datetime <- as.POSIXct(psla$local_datetime)
+#create new folder with date
+dname <- gsub('-', '', grep(max(sla$local_datetime), pattern = "(\\D+)", value = T))
+
+if(!dir.exists(paste0("upload_params_data/SLA/", dname))){
+  dir.create(paste0("upload_params_data/SLA/", dname))
+}
+newdir <- paste0("upload_params_data/SLA/", dname)
+
+#previous maximum date
+prevDate <- max(psla$local_datetime)
+
+#subset new SLA values only, to be uploaded
+new_sla <- sla %>%
+    filter(local_datetime > prevDate)
+write.csv(new_sla, paste0(newdir, "/sla.csv"), row.names = FALSE)
+```
+
+Upload that new parameter data file using the API. 
+```{bash}
+#change to directory of latest date
+x=$(ls -d ~/model-vignettes/BioCro/DARPA/upload_params_data/SLA/*/ | sort -r | head -n 1)
+cd $x
+
+#add all .csv files from this diretory
+for file in *.csv; do
+  curl -X POST --data-binary @$file    http://welsch.cyverse.org:8000/bety/api/v1/traits.csv?key=uaZWRQT44fQVzDbxOET03EZJGXiEX9yUDEDiDwe4 -H "Content-Type: text/csv"
+done
+```
+

--- a/BioCro/DARPA/upload_params.Rmd
+++ b/BioCro/DARPA/upload_params.Rmd
@@ -226,7 +226,7 @@ data_path2 <- "../../../sentinel-detection/data/raw_data/biomass/field_and_green
 sheets_names2 <- excel_sheets(data_path2)
 
 # Biomass and leaf area for greenhouse pots
-leaf_biomass_gh <- read_excel(data_path2, sheets_names2[14]) %>% 
+leaf_biomass_gh <- read_excel(data_path2, sheets_names2[16]) %>% 
   dplyr::rename(leaf_dry_biomass_g = 16) %>% # leaf DW was entered as g instead of mg
   filter(treatment == "pot") %>% 
   mutate(leaf_dry_biomass_g == as.numeric(leaf_dry_biomass_g))
@@ -241,13 +241,13 @@ sla_gh <- left_join(leaf_area_gh, leaf_biomass_gh, by = "plant_id") %>%
          dry_biomass_kg = ud.convert(leaf_dry_biomass_g, "g", "kg"), 
          area_m2 = ud.convert(leaf_area_cm2, "cm2", "m2"), 
          SLA = area_m2 / dry_biomass_kg) %>% 
-  mutate(local_datetime = as.Date(`harvested`), 
+  mutate(local_datetime = as.Date(`harvest_time`), 
          treatment = "greenhouse") %>% 
   select(local_datetime, treatment, SLA) %>% 
   mutate(statname = '')
 
 # Biomass and leaf area for 2nd field experiment, 5 cm
-leaf_biomass_5cm <- read_excel(data_path2, sheets_names2[6]) %>% 
+leaf_biomass_5cm <- read_excel(data_path2, sheets_names2[7]) %>% 
   dplyr::rename(leaf_dry_biomass_g = 16) %>% # leaf DW was entered as g instead of mg
   filter(treatment == "5cm") %>% 
   mutate(leaf_dry_biomass_g == as.numeric(leaf_dry_biomass_g))
@@ -262,13 +262,13 @@ sla_5cm <- left_join(leaf_area_5cm, leaf_biomass_5cm, by = "plant_id") %>%
          dry_biomass_kg = ud.convert(leaf_dry_biomass_g, "g", "kg"), 
          area_m2 = ud.convert(leaf_area_cm2, "cm2", "m2"), 
          SLA = area_m2 / dry_biomass_kg) %>% 
-  mutate(local_datetime = as.Date(`harvested`), 
+  mutate(local_datetime = as.Date(`harvest_time`), 
          treatment = "outdoor 5 cm density") %>% 
   select(local_datetime, treatment, SLA) %>% 
   mutate(statname = '')
 
 # Biomass and leaf area for 2nd field experiment, JollyG
-leaf_biomass_JollyG <- read_excel(data_path2, sheets_names2[6]) %>% 
+leaf_biomass_JollyG <- read_excel(data_path2, sheets_names2[7]) %>% 
   dplyr::rename(leaf_dry_biomass_g = 16) %>% # leaf DW was entered as g instead of mg
   filter(treatment == "jolly_pot") %>% 
   mutate(leaf_dry_biomass_g == as.numeric(leaf_dry_biomass_g))
@@ -283,7 +283,7 @@ sla_JollyG <- left_join(leaf_area_JollyG, leaf_biomass_JollyG, by = "plant_id") 
          dry_biomass_kg = ud.convert(leaf_dry_biomass_g, "g", "kg"), 
          area_m2 = ud.convert(leaf_area_cm2, "cm2", "m2"), 
          SLA = area_m2 / dry_biomass_kg) %>% 
-  mutate(local_datetime = as.Date(`harvested`), 
+  mutate(local_datetime = as.Date(`harvest_time`), 
          treatment = "outdoor JollyG soil") %>% 
   select(local_datetime, treatment, SLA) %>% 
   mutate(statname = '')
@@ -302,12 +302,11 @@ sla <- bind_rows(sla_hightemp, sla_control, sla_gh, sla_5cm, sla_JollyG) %>%
          citation_author = "Zhang, Gehan, LeBauer, Riemer, Tarin, Vargas",
          citation_year = "2018", 
          citation_title = "Unpublished DARPA experimental data",
-         n = 1, 
          access_level = "2",
          SLA = round(SLA, 2)) %>%
   select(citation_author, citation_year, citation_title, 
          species, cultivar, site, treatment, local_datetime, 
-         SLA, n, access_level)
+         SLA, access_level)
 
 write.csv(sla, file = "upload_params_data/SLA/sla.csv", row.names = FALSE)
 ```

--- a/BioCro/DARPA/upload_params.Rmd
+++ b/BioCro/DARPA/upload_params.Rmd
@@ -149,20 +149,24 @@ done
 
 ## Specific leaf area
 
-These SLA values are only for the high night temperature treatment from experiment 3rd_Biomass_ME034_GA_Exp. Read in, clean up, and combine leaf biomass measurements with corresponding leaf area measurements. 
+These SLA values are calculated from leaf area and leaf dry biomass. Below, the data are read in, filtered, and combined to produce specific leaf area in units of m2/kg. 
 
 These are the final columns:
 
 1. `local_datetime`: convert date into machine readable format
 2. `treatment`: specifies record's treatment using BETYdb treatment names
-3. `SLA`: measured values of specific leaf area
+3. `SLA`: values of specific leaf area in m2/kg
+
+First, load in data from the chamber experiments, an Excel sheet entitled "manual-measurements-Darpa_setaria_chambers_experiments.xlsx", which consists of multiple tabs. All leaf areas are avaiable in tab 'total_leaf_area'; biomass for the high night temperature experiment are found in '3rd_Biomass_ME034_GA_Exp' and the biomass for the high light experiment are found in '5th_Biomass_A10&ME034_cycling_t'. Note that because physiological and biomass data were taken on different individual plants, unique filters are applied to each biomass data to obtain the same set of experimental conditions as the physiological data. 
 ```{r}
-data_path <- "../../../model-vignettes-data/manual-measurements-Darpa_setaria_chambers_experiments.xlsx"
+# Data from chamber experiments
+data_path <- "../../../sentinel-detection/data/raw_data/biomass/manual-measurements-Darpa_setaria_chambers_experiments.xlsx"
 sheets_names <- excel_sheets(data_path)
 
+# Biomass and leaf area for high light treatment, 31_31_250
 leaf_biomass_hightemp <- read_excel(data_path, sheets_names[11]) %>% 
-  rename(temperature = 6, 
-         leaf_dry_biomass_mg = 19) %>% 
+  dplyr::rename(temperature = 6, 
+                leaf_dry_biomass_mg = 19) %>% 
   filter(temperature == "31.0", 
          `light_intensity(umol/m2/s)` == "250.0",
          !is.na(leaf_dry_biomass_mg), 
@@ -170,7 +174,7 @@ leaf_biomass_hightemp <- read_excel(data_path, sheets_names[11]) %>%
   mutate(leaf_dry_biomass_mg == as.numeric(leaf_dry_biomass_mg))
 
 leaf_area_hightemp <- read_excel(data_path, sheets_names[2]) %>% 
-  rename(leaf_area_cm2 = 8) %>% 
+  dplyr::rename(leaf_area_cm2 = 8) %>% 
   filter(experiment == "3rd_Biomass_ME034_GA", 
          treatment == "control")
 
@@ -184,8 +188,10 @@ sla_hightemp <- left_join(leaf_biomass_hightemp, leaf_area_hightemp, by = "plant
   select(local_datetime, treatment, SLA) %>% 
   mutate(statname = '')
 
+
+# Biomass and leaf area for control treatment, 31_22_450
 leaf_biomass_control <- read_excel(data_path, sheets_names[7]) %>% 
-  rename(temperature = 6, 
+  dplyr::rename(temperature = 6, 
          leaf_dry_biomass_mg = 19, 
          plantID = 1) %>% 
   filter(temperature == "31/22", 
@@ -193,7 +199,7 @@ leaf_biomass_control <- read_excel(data_path, sheets_names[7]) %>%
          !is.na(leaf_dry_biomass_mg))
 
 leaf_area_control <- read_excel(data_path, sheets_names[2]) %>% 
-  rename(leaf_area_cm2 = 8) %>% 
+  dplyr::rename(leaf_area_cm2 = 8) %>% 
   filter(experiment == "5th_Biomass_A10&ME034_cycling_temp")
 
 sla_control <- left_join(leaf_biomass_control, leaf_area_control, by = "plantID") %>% 

--- a/BioCro/DARPA/upload_params_data/BETY/Compare_BETY_to_upload.Rmd
+++ b/BioCro/DARPA/upload_params_data/BETY/Compare_BETY_to_upload.Rmd
@@ -12,6 +12,7 @@ Load libraries and both sets of data
 ```{r}
 options(scipen = 999)
 library(dplyr)
+library(tidyr)
 library(arsenal)
 ```
 
@@ -21,9 +22,10 @@ filename <- max(as.numeric(substr(list.files(pattern = "csv"), 1,8)))
 in_bety <- read.csv(paste0(filename, ".csv"), header = T)
 ```
 
-For comparison, import the full upload_params_data data file.
+For comparison, import the full upload_params_data data file for phys_params and SLA.
 ```{r}
-in_upload <- read.csv("../phys_params/phys_parameters.csv",  header = T)
+in_phys <- read.csv("../phys_params/phys_parameters.csv",  header = T)
+in_sla <- read.csv("../SLA/sla.csv",  header = T)
 ```
 
 Convert the treatment and variable ID columns to match upload data format. 
@@ -41,7 +43,8 @@ bety <- in_bety %>%
                               variable_id == "404" ~ "stomatal_slope.BB",
                               variable_id == "4" ~ "Vcmax",
                               variable_id == "2000000027" ~ "theta",
-                              variable_id == "38" ~ "cuticular_cond"),
+                              variable_id == "38" ~ "cuticular_cond",
+                              variable_id == "15" ~ "SLA"),
          site = case_when(site_id == "9000000005" ~ "Donald Danforth Plant Science Center Greenhouse",
                           site_id == "9000000004" ~ "Donald Danforth Plant Science Center Growth Chamber",
                           site_id == "9000000006" ~ "Donald Danforth Plant Science Center Outdoor"),
@@ -52,12 +55,16 @@ bety <- in_bety %>%
   select(-date, -entity) 
 
 bety <- bety %>%
-  mutate_if(sapply(bety, is.character), as.factor)
+  mutate_if(sapply(bety, is.character), as.factor) %>%
+  mutate_if(sapply(bety, is.integer), as.numeric)
+
+#reorder
+bety <- bety[order(bety$site, bety$treatment, bety$variable, bety$mean),]
 ```
 
-Create matching version of upload data. 
+Create matching version of uploaded phys_params. 
 ```{r}
-upload <- in_upload %>%
+phys <- in_phys %>%
   select(site, treatment, variable, mean, SE, entity) %>%
   arrange(site, treatment, variable, entity) %>%
   mutate(n = case_when(!is.na(SE) ~ 1,
@@ -66,9 +73,33 @@ upload <- in_upload %>%
   select(site, treatment, variable, mean, n, SE)
 ```
 
+Create matching version of uploaded sla 
+```{r}
+sla <- in_sla %>%
+  tidyr::gather(SLA, key = "variable", value = "mean") %>%
+  mutate(entity = NA, 
+         SE = NA)%>%
+  select(site, treatment, variable, mean, SE, entity) %>%
+  arrange(site, treatment, variable, entity) %>%
+  mutate(n = case_when(!is.na(SE) ~ 1,
+                       is.na(SE) ~ NA_real_)) %>%
+  select(-entity) %>%
+  select(site, treatment, variable, mean, n, SE)
+```
+
+Combine traits
+```{r}
+all <- rbind.data.frame(phys, sla)
+all$variable <- factor(all$variable, 
+                       levels = unique(all$variable)[c(1,2,3,7,4,5,6)])
+
+#reorder
+all <- all[order(all$site, all$treatment, all$variable, all$mean),]
+```
+
 Compare both data versions. 
 ```{r}
-compare(bety, upload)
+compare(bety, all)
 ```
 
 If no differences, should return 0 variables and 0 observations not shared, differences found in 0/5 variables, and 0 variables compared have non-identical attributes. 


### PR DESCRIPTION
This rendition of upload_params.Rmd accounts for the new data file provided by Danforth and the repo reorganization. Both datasets (data/derived_data/parameters_data.csv and data/raw_data/biomass/field_and_greenhouse_experiments.xlsx) are now in sentinel-detection. 

The upload_params folder for outputs is now subdivided into phys_params and SLA. The full dataset resides within the subfolder, while the script separates the latest data by the date of the previous upload, to avoid duplication in BETY. 

Note that lines 103-134 and 327-343 will not fully run during the test, because they are designed to output only new data. 