### PR TITLE
Migrate all Pecan OSF pages to this repo

### DIFF
--- a/infrastructure/UA_HPC_runs.Rmd
+++ b/infrastructure/UA_HPC_runs.Rmd
@@ -1,0 +1,66 @@
+---
+title: "Run PEcAn Models on UA HPC"
+output: github_document
+urlcolor: blue
+---
+
+For models that require a lot of ensemble runs or runs across different locations, the model runs themselves should be done with the greater resources of the [UA HPC](https://it.arizona.edu/service/high-performance-computing). 
+
+
+Do PEcAn workflow from beginning up through writing model-specific configuration files on local server in RStudio, then the model runs on HPC, then the remainder back on local server. The [PEcAn remote package](https://github.com/PecanProject/pecan/tree/develop/base/remote) has most of the infrastructure to transfer files back and forth. 
+
+**Using Welsch as local server**
+
+1. Modify pecan.xml
+    - ED2 example
+    - Path to binary on HPC
+    - Host block for UA HPC (edit name if using an alias in ssh config, add NetID username, specify ncpus, mem, and walltime for size of run)
+    - outdir and dbfiles paths should still be local 
+
+```
+  <host>
+      <name>login.ocelote.hpc.arizona.edu</name>
+      <user>hpc_username_here</user>
+      <qsub>qsub -N @NAME@ -W group_list=dlebauer -q standard -l select=1:ncpus=1:mem=6gb -l walltime=4:0:0 -o @STDOUT@ -e @STDERR@ -S /bin/bash</qsub>
+      <qsub.jobid>([0-9]+).head1.cm.cluster</qsub.jobid>
+      <qstat>'qstat -J @JOBID@ &amp;> /dev/null || echo DONE'</qstat>
+  </host>
+```
+
+2. Set up tunnel to HPC
+    - Generate HPC and ocelote hosts in ssh configuration file `~/.ssh/config` by running `sshkey.sh` from `pecan/scripts` in Terminal and entering correct host name each time
+    - Manually edit `~/.ssh/config` ocelote portion to the following, making sure to keep correct `User`:
+
+```
+Host login.ocelote.hpc.arizona.edu
+  HostName login.ocelote.hpc.arizona.edu
+  User NetID
+  IdentityFile ~/.ssh/hpc.arizona.edu
+  ServerAliveInterval 300
+  ControlMaster auto 
+  ControlPath /tmp/%r@%h:%p
+  ProxyCommand ssh -xaqW%h:22 hpc.arizona.edu
+```
+
+    - Adding public key to HPC; shown by .pub files in `~/.ssh/` 
+    - sftp?
+
+3. Copy files to HPC
+    - What of this does Pecan remote do automatically?
+    - Get copy of Pecan repo: `git clone https://github.com/PecanProject/pecan.git` 
+    - Create copy of shell script `ed2_2.2.0_singularity.sh` to run model binary
+    - Create copy of model binary `pecan-model-ed2.sif` (may have to modify path to this in shell script)
+    - Transfer data files? 
+
+4. (optional) From serial to parallel runs
+    - Compile modellauncher on HPC
+        1. `module load openmpi`
+        2. Run `make` from `pecan/contrib/modellauncher`
+        3. May return some warnings, check for `modellauncher/` folder
+    - 
+
+
+
+**Using OpenStack as local server**
+
+TBD

--- a/infrastructure/UA_HPC_runs.md
+++ b/infrastructure/UA_HPC_runs.md
@@ -1,0 +1,77 @@
+Run PEcAn Models on UA HPC
+================
+
+For models that require a lot of ensemble runs or runs across different
+locations, the model runs themselves should be done with the greater
+resources of the [UA
+HPC](https://it.arizona.edu/service/high-performance-computing).
+
+Do PEcAn workflow from beginning up through writing model-specific
+configuration files on local server in RStudio, then the model runs on
+HPC, then the remainder back on local server. The [PEcAn remote
+package](https://github.com/PecanProject/pecan/tree/develop/base/remote)
+has most of the infrastructure to transfer files back and forth.
+
+**Using Welsch as local server**
+
+1.  Modify pecan.xml
+      - ED2 example
+      - Path to binary on HPC
+      - Host block for UA HPC (edit name if using an alias in ssh
+        config, add NetID username, specify ncpus, mem, and walltime for
+        size of run)
+      - outdir and dbfiles paths should still be local
+
+<!-- end list -->
+
+``` 
+  <host>
+      <name>login.ocelote.hpc.arizona.edu</name>
+      <user>hpc_username_here</user>
+      <qsub>qsub -N @NAME@ -W group_list=dlebauer -q standard -l select=1:ncpus=1:mem=6gb -l walltime=4:0:0 -o @STDOUT@ -e @STDERR@ -S /bin/bash</qsub>
+      <qsub.jobid>([0-9]+).head1.cm.cluster</qsub.jobid>
+      <qstat>'qstat -J @JOBID@ &amp;> /dev/null || echo DONE'</qstat>
+  </host>
+```
+
+2.  Set up tunnel to HPC
+      - Generate HPC and ocelote hosts in ssh configuration file
+        `~/.ssh/config` by running `sshkey.sh` from `pecan/scripts` in
+        Terminal and entering correct host name each time
+      - Manually edit `~/.ssh/config` ocelote portion to the following,
+        making sure to keep correct `User`:
+
+<!-- end list -->
+
+    Host login.ocelote.hpc.arizona.edu
+      HostName login.ocelote.hpc.arizona.edu
+      User NetID
+      IdentityFile ~/.ssh/hpc.arizona.edu
+      ServerAliveInterval 300
+      ControlMaster auto 
+      ControlPath /tmp/%r@%h:%p
+      ProxyCommand ssh -xaqW%h:22 hpc.arizona.edu
+
+    - Adding public key to HPC; shown by .pub files in `~/.ssh/` 
+    - sftp?
+
+3.  Copy files to HPC
+      - What of this does Pecan remote do automatically?
+      - Get copy of Pecan repo: `git clone
+        https://github.com/PecanProject/pecan.git`
+      - Create copy of shell script `ed2_2.2.0_singularity.sh` to run
+        model binary
+      - Create copy of model binary `pecan-model-ed2.sif` (may have to
+        modify path to this in shell script)
+      - Transfer data files?
+4.  (optional) From serial to parallel runs
+      - Compile modellauncher on HPC
+        
+        1.  `module load openmpi`
+        2.  Run `make` from `pecan/contrib/modellauncher`
+        3.  May return some warnings, check for `modellauncher/` folder
+    
+      - 
+**Using OpenStack as local server**
+
+TBD

--- a/infrastructure/openstack_pecan.Rmd
+++ b/infrastructure/openstack_pecan.Rmd
@@ -1,0 +1,156 @@
+---
+title: "Create PEcAn Docker Development Environment on OpenStack Server"
+output: github_document
+urlcolor: blue
+---
+
+**Tombstone** is a private cloud of Cyverse's, which has compute nodes (hardware) at UITS. 
+
+**OpenStack** is run on these compute nodes; OpenStack is way of creating virtual machines (i.e., servers). 
+
+**Exosphere** is a way to access a bunch of OpenStack clouds and manage virtual machines on those clouds. (note: Exosphere is optional to use here, it is just used to launch virtual machines)
+
+Our OpenStack cloud is called "tombstone-cloud", we are working on project called "cals" and we are creating a new virtual machine here. 
+
+Additional notes for running on HPC are here: https://hackmd.io/4fZ0EEYgQ06Jf-TTFTliUg
+
+### Set up OpenStack account (one time only)
+
+* Get OpenStack credentials for cloud (Julian for Tombstone)
+* Access Exosphere interface. Either
+  * [Use the Exosphere Web Portal](https://try.exosphere.app/) OR
+  * [Download and install on your computer](https://try.exosphere.app/packages/)
+* In Exosphere, add new OpenStack Project
+* Either: 
+  * Enter openrc and password from [stache](https://stache.arizona.edu/) OR
+  * Enter credentials
+    * keystone auth url: https://tombstone-cloud.cyverse.org:5000/v3
+    * user domain: cso
+    * username (in stache)
+    * password (in stache)
+* Our group is using OpenStack cloud called tombstone, select check box for "cals -- CALS Project" and hit "Choose"
+* If you hit "Remove Project", just repeat these instructions to get it back
+
+### Set up new server
+
+* Click "Create" and then "Server"
+* Choose a descriptive name for your server 
+* Choose image "Ubuntu-18.0.4.raw"
+* Choose size "medium2" (2-4 CPUs, 8-16 GB ram)
+* Under "Choose a root disk size", select 'Custom disk size', choose at least 100 GB
+* If you have had an OpenStack ssh keypair created, at this step under "Advanced Options", select "Show" and add that
+* Hit "Create"
+* The new virtual machine should show up in list of servers on Tombstone as building
+* Once the server is created, lock it immediately so it can't be changed (accidentally or not) by clicking on server name and select "Lock" under "Server Actions"
+* Suspend when not using
+* After a few minutes it will be ready to use
+
+
+### Access your new server
+
+* Get into: `ssh exouser@[ip address]` 
+* Enter exouser password that you can find in the Exosphere UI under 'show password' 
+* To keep the server running even while closed, use tmux (note: can't copy and paste from tmux terminal while using iTerm2) 
+    * Set up tmux session with `tmux`
+    * View all tmux sessions with `tmux ls`
+    * Use existing tmux session with `tmux a -t [number]`
+
+#### [Optional] create your own user
+
+```
+sudo adduser [username]
+sudo usermod -aG sudo [username] # add to sudoers
+```
+
+
+#### [Optional] Generate an ssh keypair to login from your own computer
+
+This will make it easier to connect to your virtual machine from the terminal on your own computer. 
+
+```
+ssh keygen -f [ip addresss]
+# passcode not required
+```
+
+Or use the handy PEcAn script that sets up `.ssh/config` as well
+
+```sh
+~/pecan/scripts/sshkey.sh
+```
+
+Add the public key to your server using the Exosphere interface.
+
+```
+# sudo apt install xclip 
+xclip < ~/.ssh/[ip address].pub
+```
+
+In Exosphere:
+
+* Select your server
+* Select 'Server Dashboard'
+* Select 'Accounts'
+* Select your account
+* Select 'Add Public Key'
+* paste contents of ~/.ssh/[ip address].pub
+
+
+### Install Docker and Docker Compose
+
+- Docker https://docs.docker.com/engine/install/ubuntu/#installation-methods
+- Docker Compose https://docs.docker.com/compose/install/
+
+```sh
+sudo apt update && sudo apt upgrade
+sudo apt install docker docker-compose
+```
+
+Also described in [PEcAn DEV-INTRO.md](https://github.com/PecanProject/pecan/blob/develop/DEV-INTRO.md)
+
+
+### Get dev environment set up
+
+* Fork [the Pecan repo](https://github.com/PecanProject/pecan) and `git clone` to get copy on server
+* Follow instructions in [DEV-INTRO](https://github.com/PecanProject/pecan/blob/develop/DEV-INTRO.md) to set up Docker stack
+    * You will know this works by running the `docker.sipnet.xml` and results show up in `/data/tests/sipnet`
+
+### Open web user interfaces
+
+To access web interfaces including RStudio, PEcAn, BETYdb, and Shiny Apps, you need to open an SSH tunnel from the virtual machine to your own computer.
+
+* Have to add public key to server 
+* Open an ssh tunnel 
+  * `ssh -L 127.0.0.1:8000:127.0.0.1:8000 exouser@128.196.65.110`
+  * Enter password
+* Open your browser to [http://localhost:8000/](http://localhost:8000/)
+
+
+### ssh into database
+
+* Install Postgres client: `sudo apt install postgresql-client`
+* Create an ssh keypair `./pecan/scripts/sshkey.sh`
+* Specify host port by adding a line `Port 1657` in `.ssh/config` under the welsch server information
+  * (this is specific to CyVerse OpenStack, for security it does not use default ssh port 22)
+* Mount welsch postgres to port 5433: `ssh -Nf -L 5433:localhost:5432 welsch.cyverse.org`
+
+
+????:
+
+* Find database IP address from within server by doing `docker container inspect pecan_postgres_1 | grep \"IPAddress\" | grep -v \"\"`
+* On local command line, run `ssh -N -L 127.0.0.1:5433:[database IP address]:5432 exouser@[server number]` and enter password
+* In a new window, open postgres with `psql -h 127.0.0.1 -p 5433 -U bety bety`
+* Can do this simultaneously while enabling interfaces with `ssh -N -L 127.0.0.1:5433:[database IP address]:5432 -L 127.0.0.1:8000:127.0.0.1:8000 exouser@[server number]` 
+
+### Rebuild Docker containers
+
+### ssh into HPC
+
+```
+~/pecan/scripts/sshkey.sh
+```
+
+host name: `hpc.arizona.edu`
+username: your UA login  
+
+#### connect to Welsch Bety
+

--- a/infrastructure/openstack_pecan.md
+++ b/infrastructure/openstack_pecan.md
@@ -1,0 +1,175 @@
+Create PEcAn Docker Development Environment on OpenStack Server
+================
+
+**Tombstone** is a private cloud of Cyverse’s, which has compute nodes
+(hardware) at UITS.
+
+**OpenStack** is run on these compute nodes; OpenStack is way of
+creating virtual machines (i.e., servers).
+
+**Exosphere** is a way to access a bunch of OpenStack clouds and manage
+virtual machines on those clouds. (note: Exosphere is optional to use
+here, it is just used to launch virtual machines)
+
+Our OpenStack cloud is called “tombstone-cloud”, we are working on
+project called “cals” and we are creating a new virtual machine here.
+
+Additional notes for running on HPC are here:
+<https://hackmd.io/4fZ0EEYgQ06Jf-TTFTliUg>
+
+### Set up OpenStack account (one time only)
+
+  - Get OpenStack credentials for cloud (Julian for Tombstone)
+  - Access Exosphere interface. Either
+      - [Use the Exosphere Web Portal](https://try.exosphere.app/) OR
+      - [Download and install on your
+        computer](https://try.exosphere.app/packages/)
+  - In Exosphere, add new OpenStack Project
+  - Either:
+      - Enter openrc and password from
+        [stache](https://stache.arizona.edu/) OR
+      - Enter credentials
+          - keystone auth url:
+            <https://tombstone-cloud.cyverse.org:5000/v3>
+          - user domain: cso
+          - username (in stache)
+          - password (in stache)
+  - Our group is using OpenStack cloud called tombstone, select check
+    box for “cals – CALS Project” and hit “Choose”
+  - If you hit “Remove Project”, just repeat these instructions to get
+    it back
+
+### Set up new server
+
+  - Click “Create” and then “Server”
+  - Choose a descriptive name for your server
+  - Choose image “Ubuntu-18.0.4.raw”
+  - Choose size “medium2” (2-4 CPUs, 8-16 GB ram)
+  - Under “Choose a root disk size”, select ‘Custom disk size’, choose
+    at least 100 GB
+  - If you have had an OpenStack ssh keypair created, at this step under
+    “Advanced Options”, select “Show” and add that
+  - Hit “Create”
+  - The new virtual machine should show up in list of servers on
+    Tombstone as building
+  - Once the server is created, lock it immediately so it can’t be
+    changed (accidentally or not) by clicking on server name and select
+    “Lock” under “Server Actions”
+  - Suspend when not using
+  - After a few minutes it will be ready to use
+
+### Access your new server
+
+  - Get into: `ssh exouser@[ip address]`
+  - Enter exouser password that you can find in the Exosphere UI under
+    ‘show password’
+  - To keep the server running even while closed, use tmux (note: can’t
+    copy and paste from tmux terminal while using iTerm2)
+      - Set up tmux session with `tmux`
+      - View all tmux sessions with `tmux ls`
+      - Use existing tmux session with `tmux a -t [number]`
+
+#### \[Optional\] create your own user
+
+    sudo adduser [username]
+    sudo usermod -aG sudo [username] # add to sudoers
+
+#### \[Optional\] Generate an ssh keypair to login from your own computer
+
+This will make it easier to connect to your virtual machine from the
+terminal on your own computer.
+
+    ssh keygen -f [ip addresss]
+    # passcode not required
+
+Or use the handy PEcAn script that sets up `.ssh/config` as well
+
+``` sh
+~/pecan/scripts/sshkey.sh
+```
+
+Add the public key to your server using the Exosphere interface.
+
+    # sudo apt install xclip 
+    xclip < ~/.ssh/[ip address].pub
+
+In Exosphere:
+
+  - Select your server
+  - Select ‘Server Dashboard’
+  - Select ‘Accounts’
+  - Select your account
+  - Select ‘Add Public Key’
+  - paste contents of \~/.ssh/\[ip address\].pub
+
+### Install Docker and Docker Compose
+
+  - Docker
+    <https://docs.docker.com/engine/install/ubuntu/#installation-methods>
+  - Docker Compose <https://docs.docker.com/compose/install/>
+
+<!-- end list -->
+
+``` sh
+sudo apt update && sudo apt upgrade
+sudo apt install docker docker-compose
+```
+
+Also described in [PEcAn
+DEV-INTRO.md](https://github.com/PecanProject/pecan/blob/develop/DEV-INTRO.md)
+
+### Get dev environment set up
+
+  - Fork [the Pecan repo](https://github.com/PecanProject/pecan) and
+    `git clone` to get copy on server
+  - Follow instructions in
+    [DEV-INTRO](https://github.com/PecanProject/pecan/blob/develop/DEV-INTRO.md)
+    to set up Docker stack
+      - You will know this works by running the `docker.sipnet.xml` and
+        results show up in `/data/tests/sipnet`
+
+### Open web user interfaces
+
+To access web interfaces including RStudio, PEcAn, BETYdb, and Shiny
+Apps, you need to open an SSH tunnel from the virtual machine to your
+own computer.
+
+  - Have to add public key to server
+  - Open an ssh tunnel
+      - `ssh -L 127.0.0.1:8000:127.0.0.1:8000 exouser@128.196.65.110`
+      - Enter password
+  - Open your browser to <http://localhost:8000/>
+
+### ssh into database
+
+  - Install Postgres client: `sudo apt install postgresql-client`
+  - Create an ssh keypair `./pecan/scripts/sshkey.sh`
+  - Specify host port by adding a line `Port 1657` in `.ssh/config`
+    under the welsch server information
+      - (this is specific to CyVerse OpenStack, for security it does not
+        use default ssh port 22)
+  - Mount welsch postgres to port 5433: `ssh -Nf -L 5433:localhost:5432
+    welsch.cyverse.org`
+
+????:
+
+  - Find database IP address from within server by doing `docker
+    container inspect pecan_postgres_1 | grep \"IPAddress\" | grep -v
+    \"\"`
+  - On local command line, run `ssh -N -L 127.0.0.1:5433:[database IP
+    address]:5432 exouser@[server number]` and enter password
+  - In a new window, open postgres with `psql -h 127.0.0.1 -p 5433 -U
+    bety bety`
+  - Can do this simultaneously while enabling interfaces with `ssh -N
+    -L 127.0.0.1:5433:[database IP address]:5432
+    -L 127.0.0.1:8000:127.0.0.1:8000 exouser@[server number]`
+
+### Rebuild Docker containers
+
+### ssh into HPC
+
+    ~/pecan/scripts/sshkey.sh
+
+host name: `hpc.arizona.edu` username: your UA login
+
+#### connect to Welsch Bety

--- a/infrastructure/welsch_betydb.Rmd
+++ b/infrastructure/welsch_betydb.Rmd
@@ -1,0 +1,87 @@
+---
+title: "Working With Welsch's PEcAn BETYdb Database"
+output: github_document
+urlcolor: blue
+---
+
+# BETYdb at the University of Arizona
+
+URL: http://welsch.cyverse.org:8000/bety/
+
+### **Navicat: set up Welsch BETYdb connection**
+
+### First time only 
+
+1. Get CyVerse account by requesting one on the [CyVerse website](https://user.cyverse.org/services/mine)
+2. Set up Navicat connection
+    1. [Download Navicat Premium](https://www.navicat.com/en/download/navicat-premium)
+    2. Click "Connection" button in upper left corner and select "PostgreSQL"
+    3. Click on "General" tab and in "Connection Name" field add a descriptive name, e.g., WelschBetyDB
+    4. Click on "SSH" tab, enter the following, and then click Save: 
+        - Host: welsch.cyverse.org
+        - Port: 1657
+        - User Name: CyVerse account user name
+        - Authentication Method: "Password"
+        - Password: Cyverse account password
+
+### Open connection
+
+Double click on "localhost_5432" in left-hand menu. Then double click on "bety" to open. 
+
+Run and save queries using "New Query" button. 
+
+### **SSH: set up Welsch BETYdb connection**
+
+This is all done on the command line. 
+
+### First time only 
+
+1. Get CyVerse account by requesting one on the [CyVerse website](https://user.cyverse.org/services/mine)
+
+2. Install PostgreSQL
+
+```
+brew install postgresql
+```
+
+### Open SSH tunnel 
+
+The `username@welsch.cyverse.org` argument is not an email address, but rather specifies your CyVerse account
+
+Replace "username" with your CyVerse account username
+
+```
+ssh -N -L 127.0.0.1:5433:127.0.0.1:5432 -p 1657 username@welsch.cyverse.org
+```
+
+An alternative option is to separate the last argument into two arguments and include an additional flag before them
+
+```
+ssh -N -L 127.0.0.1:5433:127.0.0.1:5432 -p 1657 -l username welsch.cyverse.org
+```
+
+Type in your CyVerse account password when prompted for a password
+
+### Open connection
+
+Open up another shell window and type in the following, replacing "username" with your CyVerse account username
+
+```
+psql -h 127.0.0.1 -p 5433 -U username bety
+```
+
+This should open up the following prompt: 
+
+```
+bety=>
+```
+
+### **Test BETYdb connection**
+
+Type in the below and execute
+
+```
+select * from sites where id = 9000000004;
+```
+
+This should return information for a growth chamber at the Donald Danforth Center in St. Louis, Missouri

--- a/infrastructure/welsch_betydb.md
+++ b/infrastructure/welsch_betydb.md
@@ -1,0 +1,84 @@
+Working With Welsch’s PEcAn BETYdb Database
+================
+
+# BETYdb at the University of Arizona
+
+URL: <http://welsch.cyverse.org:8000/bety/>
+
+### **Navicat: set up Welsch BETYdb connection**
+
+### First time only
+
+1.  Get CyVerse account by requesting one on the [CyVerse
+    website](https://user.cyverse.org/services/mine)
+2.  Set up Navicat connection
+    1.  [Download Navicat
+        Premium](https://www.navicat.com/en/download/navicat-premium)
+    2.  Click “Connection” button in upper left corner and select
+        “PostgreSQL”
+    3.  Click on “General” tab and in “Connection Name” field add a
+        descriptive name, e.g., WelschBetyDB
+    4.  Click on “SSH” tab, enter the following, and then click Save:
+          - Host: welsch.cyverse.org
+          - Port: 1657
+          - User Name: CyVerse account user name
+          - Authentication Method: “Password”
+          - Password: Cyverse account password
+
+### Open connection
+
+Double click on “localhost\_5432” in left-hand menu. Then double click
+on “bety” to open.
+
+Run and save queries using “New Query” button.
+
+### **SSH: set up Welsch BETYdb connection**
+
+This is all done on the command line.
+
+### First time only
+
+1.  Get CyVerse account by requesting one on the [CyVerse
+    website](https://user.cyverse.org/services/mine)
+
+2.  Install PostgreSQL
+
+<!-- end list -->
+
+    brew install postgresql
+
+### Open SSH tunnel
+
+The `username@welsch.cyverse.org` argument is not an email address, but
+rather specifies your CyVerse account
+
+Replace “username” with your CyVerse account username
+
+    ssh -N -L 127.0.0.1:5433:127.0.0.1:5432 -p 1657 username@welsch.cyverse.org
+
+An alternative option is to separate the last argument into two
+arguments and include an additional flag before them
+
+    ssh -N -L 127.0.0.1:5433:127.0.0.1:5432 -p 1657 -l username welsch.cyverse.org
+
+Type in your CyVerse account password when prompted for a password
+
+### Open connection
+
+Open up another shell window and type in the following, replacing
+“username” with your CyVerse account username
+
+    psql -h 127.0.0.1 -p 5433 -U username bety
+
+This should open up the following prompt:
+
+    bety=>
+
+### **Test BETYdb connection**
+
+Type in the below and execute
+
+    select * from sites where id = 9000000004;
+
+This should return information for a growth chamber at the Donald
+Danforth Center in St. Louis, Missouri

--- a/infrastructure/welsch_dev_env.Rmd
+++ b/infrastructure/welsch_dev_env.Rmd
@@ -1,0 +1,74 @@
+---
+title: "Development Environment for Welsch PEcAn"
+output: github_document
+urlcolor: blue
+---
+
+This should all happen in [Welsch](http://welsch.cyverse.org:8787/). 
+
+### Specify path for compiled files
+
+* In home directory, create new folder for compiled files, e.g., R_Libs
+* Open up .Rprofile file
+* Add another library path, e.g., `.libPaths("~/R_libs")`
+
+### Get source code
+
+* Fork [main PEcAn repo](https://github.com/pecanproject/pecan)
+* Clone this into Welsch home directory
+* Always work off of the develop branch to get most recent changes
+* Set up upstream remote as main PEcAn repo
+* Keep develop updated by doing the following: 
+    * `git fetch upstream`
+    * `git merge upstream/develop`
+    * `git push origin develop`
+
+### Compile source code
+
+* Navigate into source code folder, e.g., `cd pecan/`
+* Run `make install`, which will take a while
+* This generates compiled PEcAn packages in compiled files folder, e.g., R_Libs
+* Update compiled files by running `make install`
+
+### Change and test source code
+
+* Create branch off of develop for new feature, e.g., `git checkout -b new_feature develop`
+* Make and save changes to source files
+* Restart R session and load in just changed package(s), e.g., `library(PEcAn.db)`
+* Look at changed functions, they should not have changes yet
+* Do `install` on all affected PEcAn packages, e.g., `devtools::install("pecan/base/db")` (can't do `load_all` because other PEcAn packages won't see those loaded libraries)
+* Check that changes show up in function(s) as desired
+* Test that changes have desired effect
+
+### Add changes to PEcAn develop
+* Once changes are working, run `make document` and `make` on source code to compile
+* Test changes are working once again
+* Commit and push these changes to your fork and open up a PR in the main PEcAn repo
+
+## Appendix
+
+### Installing new R packages
+
+The necessary R packages should already be installed on Welsch. Follow these instructions below to install additional packages. 
+
+* Create a folder called `R_Libs` in your home directory
+
+![enter image description here][1]
+
+* Open up the .Rprofile file that should also be in your home directory. If there is no file there, create a new text file in home directory called .Rprofile
+
+![enter image description here][2]
+
+* Add a new line to this .Rprofile file: `.libPaths("~/R_Libs")`
+* Test that this worked by executing `.libPaths()` in the console; the first object should be a path to the new folder
+* Install R packages here by running `install.packages("pkg_name", lib = "~/R_Libs")` in the console
+
+### Installing R packages from GitHub
+
+Some additional packages are only available from GitHub. To install these, the package 'devtools' needs to be installed and loaded using `install.packages("devtools")` and `library(devtools)`. Then the function install_github() can be used. 
+
+* As an example, run `devtools::install_github("fellmk/PostJAGS/postjags")` and `library(postjags)` to obtain a small package that provides functions for summarizing and restarting JAGS and OpenBUGS models
+
+
+  [1]: https://files.osf.io/v1/resources/a4p9n/providers/osfstorage/5e4ab6d73e86a8023d6e6024?mode=render
+  [2]: https://files.osf.io/v1/resources/a4p9n/providers/osfstorage/5e4ab6463e86a8023f6e67bd?mode=render

--- a/infrastructure/welsch_dev_env.md
+++ b/infrastructure/welsch_dev_env.md
@@ -1,0 +1,89 @@
+Development Environment for Welsch PEcAn
+================
+
+This should all happen in [Welsch](http://welsch.cyverse.org:8787/).
+
+### Specify path for compiled files
+
+  - In home directory, create new folder for compiled files, e.g.,
+    R\_Libs
+  - Open up .Rprofile file
+  - Add another library path, e.g., `.libPaths("~/R_libs")`
+
+### Get source code
+
+  - Fork [main PEcAn repo](https://github.com/pecanproject/pecan)
+  - Clone this into Welsch home directory
+  - Always work off of the develop branch to get most recent changes
+  - Set up upstream remote as main PEcAn repo
+  - Keep develop updated by doing the following:
+      - `git fetch upstream`
+      - `git merge upstream/develop`
+      - `git push origin develop`
+
+### Compile source code
+
+  - Navigate into source code folder, e.g., `cd pecan/`
+  - Run `make install`, which will take a while
+  - This generates compiled PEcAn packages in compiled files folder,
+    e.g., R\_Libs
+  - Update compiled files by running `make install`
+
+### Change and test source code
+
+  - Create branch off of develop for new feature, e.g., `git checkout -b
+    new_feature develop`
+  - Make and save changes to source files
+  - Restart R session and load in just changed package(s), e.g.,
+    `library(PEcAn.db)`
+  - Look at changed functions, they should not have changes yet
+  - Do `install` on all affected PEcAn packages, e.g.,
+    `devtools::install("pecan/base/db")` (can’t do `load_all` because
+    other PEcAn packages won’t see those loaded libraries)
+  - Check that changes show up in function(s) as desired
+  - Test that changes have desired effect
+
+### Add changes to PEcAn develop
+
+  - Once changes are working, run `make document` and `make` on source
+    code to compile
+  - Test changes are working once again
+  - Commit and push these changes to your fork and open up a PR in the
+    main PEcAn repo
+
+## Appendix
+
+### Installing new R packages
+
+The necessary R packages should already be installed on Welsch. Follow
+these instructions below to install additional packages.
+
+  - Create a folder called `R_Libs` in your home directory
+
+![enter image description
+here](https://files.osf.io/v1/resources/a4p9n/providers/osfstorage/5e4ab6d73e86a8023d6e6024?mode=render)
+
+  - Open up the .Rprofile file that should also be in your home
+    directory. If there is no file there, create a new text file in home
+    directory called .Rprofile
+
+![enter image description
+here](https://files.osf.io/v1/resources/a4p9n/providers/osfstorage/5e4ab6463e86a8023f6e67bd?mode=render)
+
+  - Add a new line to this .Rprofile file: `.libPaths("~/R_Libs")`
+  - Test that this worked by executing `.libPaths()` in the console; the
+    first object should be a path to the new folder
+  - Install R packages here by running `install.packages("pkg_name", lib
+    = "~/R_Libs")` in the console
+
+### Installing R packages from GitHub
+
+Some additional packages are only available from GitHub. To install
+these, the package ‘devtools’ needs to be installed and loaded using
+`install.packages("devtools")` and `library(devtools)`. Then the
+function install\_github() can be used.
+
+  - As an example, run
+    `devtools::install_github("fellmk/PostJAGS/postjags")` and
+    `library(postjags)` to obtain a small package that provides
+    functions for summarizing and restarting JAGS and OpenBUGS models

--- a/infrastructure/welsch_overview.Rmd
+++ b/infrastructure/welsch_overview.Rmd
@@ -1,0 +1,16 @@
+---
+title: "Welsch Content and Organization"
+output: github_document
+urlcolor: blue
+---
+
+ - Welsch server is on OpenStack, which provides resources needed to generate a virtual machine of desired size. We get this service for free through CyVerse, and they also set up OpenStack domain for this. 
+ - On the server, there are a bunch of Docker containers. Detailed information is available in [the PEcAn documentation on Docker](https://pecanproject.github.io/pecan-documentation/develop/docker-index.html). 
+ - What the containers are is specified in a docker-compose.yml, which is based on the general PEcAn one at [https://github.com/PecanProject/pecan/blob/develop/docker-compose.yml](https://github.com/PecanProject/pecan/blob/develop/docker-compose.yml).
+ - There are Docker images/containers for Postgres, BETYdb, and RStudio, as well as portainer, minio, traefik, and Thredds. Three PEcAn models (sipnet, ED2, MAESPA) also have images/containers.
+ - A Docker image/container for RStudio is also available on Welsch with persistent, named volumes for users data (/home) and general purpose use (/data)
+ - Internally routed container ports are shown under `labels` (for traefik) and external ports are listed under `ports`.
+ - The monitor container controls how each model container is run. 
+ - In the .yml, network is used for the name of the virtual network (in this case, `pecan`) to allow running containers to more easily communicate with one another. 
+ - The volumes section contains the named volumes for persistent data to be mounted for some of the containers. 
+ 

--- a/infrastructure/welsch_overview.md
+++ b/infrastructure/welsch_overview.md
@@ -1,0 +1,27 @@
+Welsch Content and Organization
+================
+
+  - Welsch server is on OpenStack, which provides resources needed to
+    generate a virtual machine of desired size. We get this service for
+    free through CyVerse, and they also set up OpenStack domain for
+    this.
+  - On the server, there are a bunch of Docker containers. Detailed
+    information is available in [the PEcAn documentation on
+    Docker](https://pecanproject.github.io/pecan-documentation/develop/docker-index.html).
+  - What the containers are is specified in a docker-compose.yml, which
+    is based on the general PEcAn one at
+    <https://github.com/PecanProject/pecan/blob/develop/docker-compose.yml>.
+  - There are Docker images/containers for Postgres, BETYdb, and
+    RStudio, as well as portainer, minio, traefik, and Thredds. Three
+    PEcAn models (sipnet, ED2, MAESPA) also have images/containers.
+  - A Docker image/container for RStudio is also available on Welsch
+    with persistent, named volumes for users data (/home) and general
+    purpose use (/data)
+  - Internally routed container ports are shown under `labels` (for
+    traefik) and external ports are listed under `ports`.
+  - The monitor container controls how each model container is run.
+  - In the .yml, network is used for the name of the virtual network (in
+    this case, `pecan`) to allow running containers to more easily
+    communicate with one another.
+  - The volumes section contains the named volumes for persistent data
+    to be mounted for some of the containers.


### PR DESCRIPTION
Part of consolidating and improving UA Pecan/model documentation, moving all pages from [the PEcAn Documentation](https://osf.io/a4p9n/wiki/home/?edit&view&menu) OSF page. 